### PR TITLE
refactor settings, improve performance, and more

### DIFF
--- a/src/AmbientColor.hpp
+++ b/src/AmbientColor.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <Geode/Geode.hpp>
 
 #include "Settings.hpp"
@@ -12,18 +14,19 @@ protected:
 
 		this->m_layer = layer;
 
-		// Idk why this doesn't work
+		// // Idk why this doesn't work
+		// this does not work because the player objects are created in PlayLayer::init and we hook GJBaseGameLayer::init !
 		// this->m_player1 = layer->m_player1;
 		// this->m_player2 = layer->m_player2;
 
-		m_changeMethodWhenBlack =
-			Mod::get()->getSettingValue<bool>("on-black:change-to-screen-picker");
+		m_changeMethodWhenBlack = Settings::changeMethodWhenBlack;
 
 		return true;
 	}
 
 private:
-	GJBaseGameLayer* m_layer;
+	WeakRef<GJBaseGameLayer> m_layer;
+	Ref<CCRenderTexture> m_renderTexture;
 
 	CCPoint m_pickPos;
 
@@ -31,10 +34,9 @@ private:
 	// PlayerObject* m_player2;
 
 	bool m_changeMethodWhenBlack;
-	bool m_isFinished = true;
 
-	ccColor3B getRenderColor(CCSprite* bgSprite, Settings::ColorPicker picker);
-	CCSprite* getPickSprite();
+	ccColor3B getRenderColor(GJBaseGameLayer* layer, CCSprite* bgSprite, Settings::ColorPicker picker);
+	CCSprite* getPickSprite(GJBaseGameLayer* layer);
 
 public:
 	static AmbientColor* create(GJBaseGameLayer* layer) {
@@ -47,24 +49,7 @@ public:
 		return nullptr;
 	}
 
-	void onChange(CCObject* sender);
-	ccColor3B getScreenColor();
+	void onChange(float dt);
+	ccColor3B getScreenColor(GJBaseGameLayer* layer);
 	void setIconColor(ccColor3B color, PlayerObject* player, bool isP2 = false);
-
-	double getRenderXPos() {
-		return Mod::get()->getSettingValue<double>("render-x-pos");
-	}
-
-	double getRenderYPos() {
-		return Mod::get()->getSettingValue<double>("render-y-pos");
-	}
-
-	// Have to do this bc of CCSequence being shit
-	bool isActionFinished() {
-		return m_isFinished;
-	}
-
-	void onFinish(CCObject* sender) {
-		m_isFinished = true;
-	}
 };

--- a/src/Settings.hpp
+++ b/src/Settings.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <Geode/Geode.hpp>
 
 using namespace geode::prelude;
@@ -21,31 +22,66 @@ public:
 		NONE
 	};
 
-	static ColorPicker getPicker() {
-		if (Mod::get()->getSettingValue<std::string>("color-picker") == "Background")
-			return ColorPicker::BG;
-		return ColorPicker::SCREEN;
-	}
+	static inline bool enabled;
+	static inline PlayerColor player1Color;
+	static inline PlayerColor player2Color;
+	static inline Extra player1Extra;
+	static inline Extra player2Extra;
+	static inline ColorPicker colorPicker;
+	static inline bool changeMethodWhenBlack;
+	static inline int updateTime;
+	static inline CCPoint renderPosition;
+	static inline bool drawRenderPosition;
+	static inline bool debugColor;
 
-	static Extra getExtra(bool isP2 = false) {
-		auto setting = isP2 ? "change-p2-extra" : "change-p1-extra";
-		auto option = Mod::get()->getSettingValue<std::string>(setting);
-		
-		if (option == "Wave Trail")
-			return Extra::WAVE_TRAIL;
-		if (option == "None")
-			return Extra::NONE;
-		return Extra::GLOW;
-	}
+	static void updateSettings() {
+		enabled = Mod::get()->getSettingValue<bool>("mod-enabled");
 
-	static PlayerColor getPlayerPreference(bool isP2 = false) {
-		auto setting = isP2 ? "change-p2-color" : "change-p1-color";
-		auto preference = Mod::get()->getSettingValue<std::string>(setting);
+		auto parseChangeColor = [](const std::string& key) {
+			auto value = Mod::get()->getSettingValue<std::string>(key);
+			if (value == "Main") {
+				return MAIN;
+			} else if (value == "Secondary") {
+				return SECONDARY;
+			} else if (value == "Both") {
+				return BOTH;
+			}
 
-		if (preference == "Main")
-			return PlayerColor::MAIN;
-		if (preference == "Secondary")
-			return PlayerColor::SECONDARY;
-		return PlayerColor::BOTH;
+			return MAIN; // shouldn't happen
+		};
+
+		auto parseChangeExtra = [](const std::string& key) {
+			auto value = Mod::get()->getSettingValue<std::string>(key);
+			if (value == "None") {
+				return NONE;
+			} else if (value == "Wave Trail") {
+				return WAVE_TRAIL;
+			} else {
+				return GLOW;
+			}
+		};
+
+		player1Color = parseChangeColor("change-p1-color");
+		player2Color = parseChangeColor("change-p2-color");
+		player1Extra = parseChangeExtra("change-p1-extra");
+		player2Extra = parseChangeExtra("change-p2-extra");
+
+		auto colorp = Mod::get()->getSettingValue<std::string>("color-picker");
+		if (colorp == "Background") {
+			colorPicker = BG;
+		} else {
+			colorPicker = SCREEN;
+		}
+
+		changeMethodWhenBlack = Mod::get()->getSettingValue<bool>("on-black:change-to-screen-picker");
+		updateTime = Mod::get()->getSettingValue<int64_t>("update-time");
+
+		renderPosition = CCPoint{
+			static_cast<float>(Mod::get()->getSettingValue<double>("render-x-pos")),
+			static_cast<float>(Mod::get()->getSettingValue<double>("render-y-pos"))
+		};
+
+		drawRenderPosition = Mod::get()->getSettingValue<bool>("draw-pos");
+		debugColor = Mod::get()->getSettingValue<bool>("debug-color");
 	}
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,16 +6,9 @@
 
 using namespace geode::prelude;
 
-int globalInterval = Mod::get()->getSettingValue<int64_t>("update-time");
-
-$execute {
-	listenForSettingChanges("update-time", +[](int64_t value) { globalInterval = value; });
-}
-
 struct AmbientGJBGL : Modify<AmbientGJBGL, GJBaseGameLayer> {
 	struct Fields {
 		Ref<AmbientColor> m_ambientChanger;
-		Ref<CCSequence> seq;
 	};
 
 	bool init() {
@@ -25,25 +18,17 @@ struct AmbientGJBGL : Modify<AmbientGJBGL, GJBaseGameLayer> {
 		if (!Mod::get()->getSettingValue<bool>("mod-enabled"))
 			return true;
 
-		m_fields->m_ambientChanger = AmbientColor::create(this);
-		
-		auto ambient = m_fields->m_ambientChanger;
-		m_fields->seq = CCSequence::create(
-			CCCallFunc::create(ambient, callfunc_selector(AmbientColor::onChange)),
-			CCDelayTime::create(static_cast<float>(globalInterval) / 1000),
-			CCCallFunc::create(ambient, callfunc_selector(AmbientColor::onFinish)),
-			nullptr
+		Settings::updateSettings();
+
+		auto ambient = AmbientColor::create(this);
+		m_fields->m_ambientChanger = ambient;
+
+		ambient->schedule(
+			schedule_selector(AmbientColor::onChange),
+			static_cast<float>(Settings::updateTime) / 1000
 		);
+		ambient->onEnter();
 
 		return true;
-	}
-
-	void update(float p0) {
-		GJBaseGameLayer::update(p0);
-
-		if (!Mod::get()->getSettingValue<bool>("mod-enabled"))
-			return;
-
-		if (m_fields->m_ambientChanger->isActionFinished()) this->runAction(m_fields->seq);
 	}
 };


### PR DESCRIPTION
* Gets rid of the repeating CCSequence and replaces it with a scheduled event on `AmbientColor`
* Stores the `GJBaseGameLayer` as a `WeakRef` instead of a pointer or a `Ref`, so that `AmbientColor` can know when it gets destroyed.
* Fetches all settings only once when opening the level, instead of re-checking them every time the colors update
* Stores the `CCRenderTexture` instead of recreating it every time (didn't have any problems with that in my tests)

Note: **this requires nightly SDK**. Users don't need nightly Geode, but I fixed a pretty important bug with `WeakRef` in a [recent commit](https://github.com/geode-sdk/geode/commit/9a8939fb1d4431598ec51d41253e4f6b9dd3131a), so you **need** to build the mod with updated headers for it to work fine. I see your action already uses nightly, but for local builds you may need to update the SDK.

Please test everything and tell me if there are any issues, whether I broke functionality or you don't like / don't understand some part of the code :)